### PR TITLE
Fix runtime error in 2-structure-data.

### DIFF
--- a/aspnet/3-binary-data/3-binary-data.csproj
+++ b/aspnet/3-binary-data/3-binary-data.csproj
@@ -14,7 +14,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GoogleCloudSamples</RootNamespace>
-    <AssemblyName>2-structured-data</AssemblyName>
+    <AssemblyName>3-binary-data</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>

--- a/aspnet/3-binary-data/Properties/AssemblyInfo.cs
+++ b/aspnet/3-binary-data/Properties/AssemblyInfo.cs
@@ -18,11 +18,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("_2_structured_data")]
+[assembly: AssemblyTitle("_3_binary_data")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Google Inc")]
-[assembly: AssemblyProduct("_2_structured_data")]
+[assembly: AssemblyProduct("_3_binary_data")]
 [assembly: AssemblyCopyright("Copyright \u00A9 Google Inc 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]


### PR DESCRIPTION
The name collision with the binaries in 3-binary-data caused iisexpress to
get confused and report errors.