### PR TITLE
Fix test issues in aspnet/6-pubsub.

### DIFF
--- a/aspnet/6-pubsub/test/BookDetailLookupTest.cs
+++ b/aspnet/6-pubsub/test/BookDetailLookupTest.cs
@@ -73,9 +73,9 @@ namespace GoogleCloudSamples
 
         static BookDetailLookupTest()
         {
-            s_projectId = System.Environment.GetEnvironmentVariable("GOOGLE_PROJECT_ID");
+            s_projectId = System.Environment.GetEnvironmentVariable("GoogleCloudSamples:ProjectId");
             Assert.False(string.IsNullOrWhiteSpace(s_projectId), "Set the environment variable " +
-                "GOOGLE_PROJECT_ID to your google project id.");
+                "GoogleCloudSamples:ProjectId to your google project id.");
         }
 
         [Fact]

--- a/buildAndRunTests.ps1
+++ b/buildAndRunTests.ps1
@@ -14,19 +14,21 @@
 
 # Recursively retrieve all the files in a directory that match one of the
 # masks.
-function GetFiles($path = $pwd, [string[]]$masks = '*', $maxDepth = 0, $depth=-1)
+function GetFiles($path = $null, [string[]]$masks = '*', $maxDepth = 0, $depth=-1)
 {
-    foreach ($item in Get-ChildItem $path)
+    if (!$path) { $path = Get-Location }
+    $root = Get-Item $path
+    foreach ($item in $root.GetFiles())
     {
-        if ($masks | Where {$item -like $_})
-        {
-            $item
-        }
-        if ($maxDepth -ge 0 -and $depth -ge $maxDepth)
-        {
-            # We have reached the max depth.  Do not recurse.
-        }
-        elseif (Test-Path $item.FullName -PathType Container)
+        if ($masks | Where {$item -like $_}) { $item }
+    }
+    if ($maxDepth -ge 0 -and $depth -ge $maxDepth)
+    {
+        # We have reached the max depth.  Do not recurse.
+    }
+    else 
+    {
+        foreach ($item in $root.GetDirectories()) 
         {
             GetFiles $item.FullName $masks $maxDepth ($depth + 1)
         }


### PR DESCRIPTION
Stop using GOOGLE_PROJECT_ID in one of the tests.  Use
GoogleCloudSamples:ProjectId in all the tests.

When recursing through directory tree, run tests in parent directories
before child directories.  6-pubsub depends on that behavior.