### PR TITLE
Add the UserinfoEmail scope to datastore auth.

### DIFF
--- a/aspnet/2-structured-data/Models/DatastoreBookStore.cs
+++ b/aspnet/2-structured-data/Models/DatastoreBookStore.cs
@@ -135,7 +135,8 @@ namespace GoogleCloudSamples.Models
             var credentials = Google.Apis.Auth.OAuth2.GoogleCredential
                 .GetApplicationDefaultAsync().Result;
             credentials = credentials.CreateScoped(new[] {
-                DatastoreService.Scope.Datastore
+                DatastoreService.Scope.Datastore,
+                DatastoreService.Scope.UserinfoEmail,
             });
             // Create our connection to datastore.
             _datastore = new DatastoreService(new Google.Apis.Services


### PR DESCRIPTION
Without this additional scope, when using a service account, all datastore
calls fail with Invalid Credentials.