### PR TITLE
Use Datastore as default BookStore

### DIFF
--- a/aspnet/2-structured-data/Web.config
+++ b/aspnet/2-structured-data/Web.config
@@ -28,10 +28,10 @@
     <add key="GoogleCloudSamples:ProjectId" value="YOUR-PROJECT-ID" />
     <!--
     Set to either mysql or datastore.
-    If using mysql, update the connectionString far below, and then run update-database in the
+    If using mysql, update the connectionString far below, and then run Update-Database in the
     Package Manager Console.
     -->
-    <add key="GoogleCloudSamples:BookStore" value="mysql" />
+    <add key="GoogleCloudSamples:BookStore" value="datastore" />
     <add key="webpages:Version" value="3.0.0.0" />
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />

--- a/aspnet/3-binary-data/Web.config
+++ b/aspnet/3-binary-data/Web.config
@@ -28,10 +28,10 @@
     <add key="GoogleCloudSamples:ProjectId" value="YOUR-PROJECT-ID" />
     <!--
     Set to either mysql or datastore.
-    If using mysql, update the connectionString far below, and then run update-database in the
+    If using mysql, update the connectionString far below, and then run Update-Database in the
     Package Manager Console.
     -->
-    <add key="GoogleCloudSamples:BookStore" value="mysql" />
+    <add key="GoogleCloudSamples:BookStore" value="datastore" />
     <!-- Set to your Google Cloud Storage bucket -->
     <add key="GoogleCloudSamples:BucketName" value="YOUR-BUCKET-NAME" />
     <!-- Configure the name of your appliation (optional) -->

--- a/aspnet/6-pubsub/bookshelf/Web.config
+++ b/aspnet/6-pubsub/bookshelf/Web.config
@@ -13,10 +13,10 @@
     <add key="GoogleCloudSamples:ProjectId" value="YOUR-PROJECT-ID" />
     <!--
     Set to either mysql or datastore.
-    If using mysql, update the connectionString far below, and then run update-database in the
+    If using mysql, update the connectionString far below, and then run Update-Database in the
     Package Manager Console.
     -->
-    <add key="GoogleCloudSamples:BookStore" value="mysql" />
+    <add key="GoogleCloudSamples:BookStore" value="datastore" />
     <add key="webpages:Version" value="3.0.0.0" />
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />

--- a/aspnet/6-pubsub/lib/app.config
+++ b/aspnet/6-pubsub/lib/app.config
@@ -9,10 +9,10 @@
     <add key="GoogleCloudSamples:ProjectId" value="YOUR-PROJECT-ID" />
     <!--
     Set to either mysql or datastore.
-    If using mysql, update the connectionString far below, and then run update-database in the
+    If using mysql, update the connectionString far below, and then run Update-Database in the
     Package Manager Console.
     -->
-    <add key="GoogleCloudSamples:BookStore" value="mysql" />
+    <add key="GoogleCloudSamples:BookStore" value="datastore" />
   </appSettings>
     <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/aspnet/6-pubsub/worker/Web.config
+++ b/aspnet/6-pubsub/worker/Web.config
@@ -13,10 +13,10 @@
     <add key="GoogleCloudSamples:ProjectId" value="YOUR-PROJECT-ID" />
     <!--
     Set to either mysql or datastore.
-    If using mysql, update the connectionString far below, and then run update-database in the
+    If using mysql, update the connectionString far below, and then run Update-Database in the
     Package Manager Console.
     -->
-    <add key="GoogleCloudSamples:BookStore" value="mysql" />
+    <add key="GoogleCloudSamples:BookStore" value="datastore" />
     <add key="webpages:Version" value="3.0.0.0" />
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />


### PR DESCRIPTION
Datastore requires little-to-no configuration.  Only your project ID is required.  Cloud SQL, on the other hand, requires much more setup (create an instance, create a database, set connection string, run migrations).

Some of the published language Getting Started guides provide the following recommendation for all steps *after* 2-structured-data:

 > Set the value of dataBackend the same way you did during the [Using Structured Data](https://cloud.google.com/nodejs/getting-started/using-structured-data) tutorial. If you skipped that tutorial, leave dataBackend set to datastore.
 ~ [Node.js : Configure settings](https://cloud.google.com/nodejs/getting-started/using-cloud-storage#configure_settings)

 > Set the value of DATA_BACKEND to the same value you used during the [Using Structured Data](https://cloud.google.com/python/getting-started/using-structured-data) tutorial. If you skipped that tutorial, leave dataBackend set to datastore.
 ~ [Python : Configure settings](https://cloud.google.com/python/getting-started/using-cloud-storage#configure_settings)

Defaulting to Datastore might be easier for users.

