### PR TITLE
Propagate cloud storage code into 5-pubsub.

### DIFF
--- a/aspnet/2-structured-data/Views/Books/Form.cshtml
+++ b/aspnet/2-structured-data/Views/Books/Form.cshtml
@@ -18,7 +18,7 @@
 
 <h3>@Model.Action book</h3>
 <!-- [START form] -->
-<form action="/Books/@Model.FormAction/@Model.Book.Id" method="post" id="book-form">
+<form action="/Books/@Model.FormAction/@Model.Book.Id" method="post" id="book-form" enctype="multipart/form-data">
     @Html.AntiForgeryToken()
     <div class="form-group">
         @Html.LabelFor(model => model.Book.Title)

--- a/aspnet/3-binary-data/App_Start/UnityConfig.cs
+++ b/aspnet/3-binary-data/App_Start/UnityConfig.cs
@@ -76,6 +76,8 @@ namespace GoogleCloudSamples
             return value;
         }
 
+        public static string ProjectId => GetConfigVariable("GoogleCloudSamples:ProjectId");
+
         public static BookStoreFlag ChooseBookStoreFromConfig()
         {
             string bookStore = GetConfigVariable("GoogleCloudSamples:BookStore")?.ToLower();
@@ -104,7 +106,7 @@ namespace GoogleCloudSamples
             {
                 case BookStoreFlag.Datastore:
                     container.RegisterInstance<IBookStore>(
-                        new DatastoreBookStore(GetConfigVariable("GoogleCloudSamples:ProjectId")));
+                        new DatastoreBookStore(ProjectId));
                     break;
 
                 case BookStoreFlag.MySql:

--- a/aspnet/3-binary-data/Models/ApplicationDbContextFactory.cs
+++ b/aspnet/3-binary-data/Models/ApplicationDbContextFactory.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.Data.Entity.Infrastructure;
-using System.Diagnostics;
 
 namespace GoogleCloudSamples.Models
 {
@@ -24,6 +23,10 @@ namespace GoogleCloudSamples.Models
     /// </summary>
     public class ApplicationDbContextFactory : IDbContextFactory<ApplicationDbContext>
     {
+        /// <summary>
+        /// Check the environment variable, and create a new ApplicationDbContext accordingly.
+        /// </summary>
+        /// <returns></returns>
         public ApplicationDbContext Create()
         {
             string envConnectionString = Environment.GetEnvironmentVariable(

--- a/aspnet/3-binary-data/Models/DbBookStore.cs
+++ b/aspnet/3-binary-data/Models/DbBookStore.cs
@@ -12,7 +12,6 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-using System;
 using System.Linq;
 
 namespace GoogleCloudSamples.Models
@@ -28,6 +27,7 @@ namespace GoogleCloudSamples.Models
         {
             _dbcontext = dbcontext;
         }
+
         // [START create]
         public void Create(Book book)
         {

--- a/aspnet/5-pubsub/bookshelf/App_Start/UnityConfig.cs
+++ b/aspnet/5-pubsub/bookshelf/App_Start/UnityConfig.cs
@@ -12,6 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+using GoogleCloudSamples.Services;
 using Microsoft.Practices.Unity;
 using System;
 
@@ -43,19 +44,19 @@ namespace GoogleCloudSamples.App_Start
 
         /// <summary>Registers the type mappings with the Unity container.</summary>
         /// <param name="container">The unity container to configure.</param>
-        /// <remarks>There is no need to register concrete types such as controllers or API controllers (unless you want to
-        /// change the defaults), as Unity allows resolving a concrete type even if it was not previously registered.</remarks>
         public static void RegisterTypes(IUnityContainer container)
         {
             LibUnityConfig.RegisterTypes(container);
             var bookDetailLookup = new BookDetailLookup(LibUnityConfig.ProjectId);
             bookDetailLookup.CreateTopicAndSubscription();
             container.RegisterInstance<BookDetailLookup>(bookDetailLookup);
-            // NOTE: To load from web.config uncomment the line below. Make sure to add a Microsoft.Practices.Unity.Configuration to the using statements.
-            // container.LoadConfiguration();
 
-            // TODO: Register your types here
-            // container.RegisterType<IProductRepository, ProductRepository>();
+            container.RegisterInstance<ImageUploader>(
+                new ImageUploader(
+                  LibUnityConfig.GetConfigVariable("GoogleCloudSamples:BucketName"),
+                  LibUnityConfig.GetConfigVariable("GoogleCloudSamples:ApplicationName")
+                )
+            );
         }
     }
 }

--- a/aspnet/5-pubsub/bookshelf/App_Start/UnityMvcActivator.cs
+++ b/aspnet/5-pubsub/bookshelf/App_Start/UnityMvcActivator.cs
@@ -34,8 +34,7 @@ namespace GoogleCloudSamples.App_Start
 
             DependencyResolver.SetResolver(new UnityDependencyResolver(container));
 
-            // TODO: Uncomment if you want to use PerRequestLifetimeManager
-            // Microsoft.Web.Infrastructure.DynamicModuleHelper.DynamicModuleUtility.RegisterModule(typeof(UnityPerRequestHttpModule));
+            Microsoft.Web.Infrastructure.DynamicModuleHelper.DynamicModuleUtility.RegisterModule(typeof(UnityPerRequestHttpModule));
         }
 
         /// <summary>Disposes the Unity container when the application is shut down.</summary>

--- a/aspnet/5-pubsub/bookshelf/Global.asax
+++ b/aspnet/5-pubsub/bookshelf/Global.asax
@@ -1,1 +1,17 @@
-﻿<%@ Application Codebehind="Global.asax.cs" Inherits="GoogleCloudSamples.MvcApplication" Language="C#" %>
+﻿<%-- 
+Copyright 2015 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--%>
+
+<%@ Application Codebehind="Global.asax.cs" Inherits="GoogleCloudSamples.MvcApplication" Language="C#" %>

--- a/aspnet/5-pubsub/bookshelf/Global.asax.cs
+++ b/aspnet/5-pubsub/bookshelf/Global.asax.cs
@@ -21,6 +21,7 @@ namespace GoogleCloudSamples
     {
         protected void Application_Start()
         {
+            AreaRegistration.RegisterAllAreas();
             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
             RouteConfig.RegisterRoutes(RouteTable.Routes);
         }

--- a/aspnet/5-pubsub/bookshelf/Services/ImageUploader.cs
+++ b/aspnet/5-pubsub/bookshelf/Services/ImageUploader.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2015 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Storage.v1;
+using Google.Storage.V1;
+using System;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace GoogleCloudSamples.Services
+{
+    public class ImageUploader
+    {
+        private string _bucketName;
+        private StorageClient _storageClient;
+
+        public ImageUploader(string bucketName, string applicationName)
+        {
+            _bucketName = bucketName;
+            // [START storageclient]
+            _storageClient = StorageClient
+                .FromApplicationCredentials(applicationName).Result;
+            // [END storageclient]
+        }
+
+        // [START uploadimage]
+        public async Task<String> UploadImage(HttpPostedFileBase image, long id)
+        {
+            var imageAcl = ObjectsResource
+                .InsertMediaUpload.PredefinedAclEnum.PublicRead;
+
+            var imageObject = await _storageClient.UploadObjectAsync(
+                bucket: _bucketName,
+                objectName: id.ToString(),
+                contentType: image.ContentType,
+                source: image.InputStream,
+                options: new UploadObjectOptions { PredefinedAcl = imageAcl }
+            );
+
+            return imageObject.MediaLink;
+        }
+        // [END uploadimage]
+
+        public async Task DeleteUploadedImage(long id)
+        {
+            await _storageClient.DeleteObjectAsync(_bucketName, id.ToString());
+        }
+    }
+}

--- a/aspnet/5-pubsub/bookshelf/Views/Books/Form.cshtml
+++ b/aspnet/5-pubsub/bookshelf/Views/Books/Form.cshtml
@@ -18,7 +18,7 @@
 
 <h3>@Model.Action book</h3>
 <!-- [START form] -->
-<form action="/Books/@Model.FormAction/@Model.Book.Id" method="post" id="book-form">
+<form action="/Books/@Model.FormAction/@Model.Book.Id" method="post" id="book-form" enctype="multipart/form-data">
     @Html.AntiForgeryToken()
     <div class="form-group">
         @Html.LabelFor(model => model.Book.Title)
@@ -43,6 +43,13 @@
         @Html.EditorFor(model => model.Book.Description, new { htmlAttributes = new { @class = "form-control", @type = "text" } })
         @Html.ValidationMessageFor(model => model.Book.Description, "", new { @class = "text-danger" })
     </div>
+    <!-- [START image] -->
+    <div class="form-group">
+        @Html.Label("Cover Image")
+        <input type="file" id="image" name="image" value="@Model.Book.ImageUrl" class="form-control">
+        @Html.HiddenFor(model => model.Book.ImageUrl)
+    </div>
+    <!-- [END image] -->
 
     <button type="submit" class="btn btn-success">Save</button>
 </form>

--- a/aspnet/5-pubsub/bookshelf/Views/Web.config
+++ b/aspnet/5-pubsub/bookshelf/Views/Web.config
@@ -1,4 +1,19 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
+<!--
+  Copyright 2015 Google, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 
 <configuration>
   <configSections>
@@ -17,6 +32,7 @@
         <add namespace="System.Web.Mvc.Html" />
         <add namespace="System.Web.Optimization" />
         <add namespace="System.Web.Routing" />
+        <add namespace="GoogleCloudSamples" />
       </namespaces>
     </pages>
   </system.web.webPages.razor>

--- a/aspnet/5-pubsub/bookshelf/Web.Debug.config
+++ b/aspnet/5-pubsub/bookshelf/Web.Debug.config
@@ -1,4 +1,19 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
+<!--
+  Copyright 2015 Google, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 
 <!-- For more information on using Web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=301874 -->
 

--- a/aspnet/5-pubsub/bookshelf/Web.Release.config
+++ b/aspnet/5-pubsub/bookshelf/Web.Release.config
@@ -1,4 +1,19 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
+<!--
+  Copyright 2015 Google, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 
 <!-- For more information on using Web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=301874 -->
 

--- a/aspnet/5-pubsub/bookshelf/Web.config
+++ b/aspnet/5-pubsub/bookshelf/Web.config
@@ -1,4 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0"?>
+<!--
+  Copyright 2015 Google, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=301880
@@ -6,21 +21,25 @@
 <configuration>
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
   </configSections>
   <appSettings>
     <!-- Set to your Google project id as shown on the Google Developers Console -->
-    <add key="GoogleCloudSamples:ProjectId" value="YOUR-PROJECT-ID" />
+    <add key="GoogleCloudSamples:ProjectId" value="YOUR-PROJECT-ID"/>
     <!--
     Set to either mysql or datastore.
     If using mysql, update the connectionString far below, and then run Update-Database in the
     Package Manager Console.
     -->
-    <add key="GoogleCloudSamples:BookStore" value="datastore" />
-    <add key="webpages:Version" value="3.0.0.0" />
-    <add key="webpages:Enabled" value="false" />
-    <add key="ClientValidationEnabled" value="true" />
-    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+    <add key="GoogleCloudSamples:BookStore" value="datastore"/>
+    <!-- Set to your Google Cloud Storage bucket -->
+    <add key="GoogleCloudSamples:BucketName" value="YOUR-BUCKET-NAME"/>
+    <!-- Configure the name of your appliation (optional) -->
+    <add key="GoogleCloudSamples:ApplicationName" value="Bookshelf Sample"/>
+    <add key="webpages:Version" value="3.0.0.0"/>
+    <add key="webpages:Enabled" value="false"/>
+    <add key="ClientValidationEnabled" value="true"/>
+    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -31,69 +50,69 @@
       </system.Web>
   -->
   <system.web>
-    <compilation debug="true" targetFramework="4.5" />
-    <httpRuntime targetFramework="4.5" />
+    <compilation debug="true" targetFramework="4.5.2"/>
+    <httpRuntime targetFramework="4.5"/>
   </system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0" />
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797" />
+        <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797" />
+        <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <connectionStrings>
-    <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd=" />
+    <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd="/>
   </connectionStrings>
   <entityFramework>
-    <defaultConnectionFactory type="MySql.Data.Entity.MySqlConnectionFactory, EntityFramework" />
+    <defaultConnectionFactory type="MySql.Data.Entity.MySqlConnectionFactory, EntityFramework"/>
     <providers>
-      <provider invariantName="MySql.Data.MySqlClient" type="MySql.Data.MySqlClient.MySqlProviderServices, MySql.Data.Entity.EF6, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+      <provider invariantName="MySql.Data.MySqlClient" type="MySql.Data.MySqlClient.MySqlProviderServices, MySql.Data.Entity.EF6, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"/>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
     </providers>
   </entityFramework>
   <system.data>
     <DbProviderFactories>
-      <remove invariant="MySql.Data.MySqlClient" />
-      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
+      <remove invariant="MySql.Data.MySqlClient"/>
+      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"/>
     </DbProviderFactories>
   </system.data>
   <system.codedom>
     <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701" />
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701"/>
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"/>
     </compilers>
   </system.codedom>
 </configuration>

--- a/aspnet/5-pubsub/bookshelf/bookshelf.csproj
+++ b/aspnet/5-pubsub/bookshelf/bookshelf.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GoogleCloudSamples</RootNamespace>
     <AssemblyName>bookshelf</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
@@ -44,12 +44,48 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BouncyCastle.Crypto, Version=1.7.4137.9688, Culture=neutral, PublicKeyToken=a4292a325f69b123, processorArchitecture=MSIL">
+      <HintPath>..\packages\BouncyCastle.1.7.0\lib\Net40-Client\BouncyCastle.Crypto.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Google.Apis, Version=1.11.0.17797, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.1.11.0\lib\net45\Google.Apis.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Google.Apis.Auth, Version=1.11.0.17798, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Auth.1.11.0\lib\net45\Google.Apis.Auth.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.11.0.17800, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Auth.1.11.0\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Google.Apis.Core, Version=1.11.0.17797, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Core.1.11.0\lib\net45\Google.Apis.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Google.Apis.PlatformServices, Version=1.11.0.17798, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.1.11.0\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Google.Apis.Storage.v1, Version=1.10.0.55, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Storage.v1.1.10.0.550\lib\portable-net40+sl50+win+wpa81+wp80\Google.Apis.Storage.v1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Google.Storage.V1, Version=0.1.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Storage.V1.0.1.0-CI00031\lib\net451\Google.Storage.V1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -103,6 +139,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -119,6 +156,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
@@ -159,6 +197,7 @@
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="WebActivatorEx, Version=2.0.0.0, Culture=neutral, PublicKeyToken=7b26dc2a43f6a0d4, processorArchitecture=MSIL">
       <HintPath>..\packages\WebActivatorEx.2.0\lib\net40\WebActivatorEx.dll</HintPath>
       <Private>True</Private>
@@ -170,6 +209,10 @@
     <Reference Include="Antlr3.Runtime">
       <Private>True</Private>
       <HintPath>..\packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="Zlib.Portable, Version=1.11.0.0, Culture=neutral, PublicKeyToken=431cba815f6a8b5b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Zlib.Portable.Signed.1.11.0\lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch+MonoAndroid\Zlib.Portable.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -183,6 +226,7 @@
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Services\ImageUploader.cs" />
     <Compile Include="ViewModels\Books\Form.cs" />
     <Compile Include="ViewModels\Books\Index.cs" />
   </ItemGroup>

--- a/aspnet/5-pubsub/bookshelf/packages.config
+++ b/aspnet/5-pubsub/bookshelf/packages.config
@@ -2,10 +2,17 @@
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net452" />
   <package id="bootstrap" version="3.0.0" targetFramework="net452" />
+  <package id="BouncyCastle" version="1.7.0" targetFramework="net452" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
+  <package id="Google.Apis" version="1.11.0" targetFramework="net452" />
+  <package id="Google.Apis.Auth" version="1.11.0" targetFramework="net452" />
+  <package id="Google.Apis.Core" version="1.11.0" targetFramework="net452" />
+  <package id="Google.Apis.Storage.v1" version="1.10.0.550" targetFramework="net452" />
+  <package id="Google.Storage.V1" version="0.1.0-CI00031" targetFramework="net452" />
   <package id="jQuery" version="1.10.2" targetFramework="net452" />
   <package id="jQuery.Validation" version="1.11.1" targetFramework="net452" />
+  <package id="log4net" version="2.0.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net452" />
@@ -27,4 +34,5 @@
   <package id="Unity.Mvc" version="4.0.1" targetFramework="net452" />
   <package id="WebActivatorEx" version="2.0" targetFramework="net452" />
   <package id="WebGrease" version="1.5.2" targetFramework="net452" />
+  <package id="Zlib.Portable.Signed" version="1.11.0" targetFramework="net452" />
 </packages>

--- a/aspnet/5-pubsub/bookshelf/test.js
+++ b/aspnet/5-pubsub/bookshelf/test.js
@@ -28,7 +28,7 @@ casper.thenOpen(host + '/Books', function (response) {
 casper.thenClick('#add-book', function () {
     console.log('Clicked Add book.  New location is ' + this.getCurrentUrl());
     this.test.assertExists({ type: 'xpath', path: '//input[@type="file"]' },
-    'The Form element "image" exists for uploading book cover images .');
+    'The Form element "image" exists for uploading book cover images.');
     this.fill('form#book-form', {
         'Book.Title': 'test.js',
         'Book.Author': 'test.js',

--- a/aspnet/5-pubsub/bookshelf/test.js
+++ b/aspnet/5-pubsub/bookshelf/test.js
@@ -27,6 +27,8 @@ casper.thenOpen(host + '/Books', function (response) {
 
 casper.thenClick('#add-book', function () {
     console.log('Clicked Add book.  New location is ' + this.getCurrentUrl());
+    this.test.assertExists({ type: 'xpath', path: '//input[@type="file"]' },
+    'The Form element "image" exists for uploading book cover images .');
     this.fill('form#book-form', {
         'Book.Title': 'test.js',
         'Book.Author': 'test.js',

--- a/aspnet/5-pubsub/lib/BookDetailLookup.cs
+++ b/aspnet/5-pubsub/lib/BookDetailLookup.cs
@@ -232,7 +232,7 @@ namespace GoogleCloudSamples
             book.PublishedDate = info.publishedDate;
             book.Author = string.Join(", ", info.authors);
             book.Description = info.description;
-            // TODO: update image.
+            book.ImageUrl = info.imageLinks.thumbnail;
             bookStore.Update(book);
         }
         // [END processbook]

--- a/aspnet/5-pubsub/lib/Models/Book.cs
+++ b/aspnet/5-pubsub/lib/Models/Book.cs
@@ -19,8 +19,7 @@ using System.Web.Mvc;
 namespace GoogleCloudSamples.Models
 {
     // [START book]
-    [Bind(Include = "Title, Author, PublishedDate, Description")]
-
+    [Bind(Include = "Title, Author, PublishedDate, Description, ImageUrl")]
     public class Book
     {
         [Key]
@@ -42,6 +41,5 @@ namespace GoogleCloudSamples.Models
 
         public string CreatedById { get; set; }
     }
-
     // [END book]
 }

--- a/aspnet/5-pubsub/lib/Models/DatastoreBookStore.cs
+++ b/aspnet/5-pubsub/lib/Models/DatastoreBookStore.cs
@@ -96,7 +96,6 @@ namespace GoogleCloudSamples.Models
             entity.Properties["CreateById"] = NewProperty(book.CreatedById);
             return entity;
         }
-
         // [END toentity]
 
         /// <summary>
@@ -167,7 +166,6 @@ namespace GoogleCloudSamples.Models
             return _datastore.Datasets.Commit(commitRequest, _projectId)
                 .Execute();
         }
-
         // [END commitmutation]
 
         // [START create]
@@ -179,7 +177,6 @@ namespace GoogleCloudSamples.Models
             });
             book.Id = result.MutationResult.InsertAutoIdKeys.First().Path.First().Id.Value;
         }
-
         // [END create]
 
         public void Delete(long id)
@@ -219,7 +216,6 @@ namespace GoogleCloudSamples.Models
                     ? response.Batch.EndCursor : null,
             };
         }
-
         // [END list]
 
         public Book Read(long id)

--- a/aspnet/5-pubsub/lib/Models/DbBookStore.cs
+++ b/aspnet/5-pubsub/lib/Models/DbBookStore.cs
@@ -35,7 +35,6 @@ namespace GoogleCloudSamples.Models
             _dbcontext.SaveChanges();
             book.Id = trackBook.Id;
         }
-
         // [END create]
         public void Delete(long id)
         {
@@ -60,7 +59,6 @@ namespace GoogleCloudSamples.Models
                 NextPageToken = books.Count() == pageSize ? books.Last().Id.ToString() : null
             };
         }
-
         // [END list]
 
         public Book Read(long id)

--- a/aspnet/5-pubsub/lib/app.config
+++ b/aspnet/5-pubsub/lib/app.config
@@ -1,49 +1,53 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
   </configSections>
   <appSettings>
     <!-- Set to your Google project id as shown on the Google Developers Console -->
-    <add key="GoogleCloudSamples:ProjectId" value="YOUR-PROJECT-ID" />
+    <add key="GoogleCloudSamples:ProjectId" value="YOUR-PROJECT-ID"/>
     <!--
     Set to either mysql or datastore.
     If using mysql, update the connectionString far below, and then run Update-Database in the
     Package Manager Console.
     -->
-    <add key="GoogleCloudSamples:BookStore" value="datastore" />
+    <add key="GoogleCloudSamples:BookStore" value="datastore"/>
   </appSettings>
     <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="System.Web.Mvc" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+			</dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0" />
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797" />
+        <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797" />
+        <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <connectionStrings>
-    <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd=" />
+    <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd="/>
   </connectionStrings>
   <entityFramework>
     <defaultConnectionFactory type="MySql.Data.Entity.MySqlConnectionFactory, EntityFramework"></defaultConnectionFactory>
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
-      <provider invariantName="MySql.Data.MySqlClient" type="MySql.Data.MySqlClient.MySqlProviderServices, MySql.Data.Entity.EF6, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
+      <provider invariantName="MySql.Data.MySqlClient" type="MySql.Data.MySqlClient.MySqlProviderServices, MySql.Data.Entity.EF6, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"/>
     </providers>
   </entityFramework>
   <system.data>
     <DbProviderFactories>
-      <remove invariant="MySql.Data.MySqlClient" />
-      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
+      <remove invariant="MySql.Data.MySqlClient"/>
+      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"/>
     </DbProviderFactories>
   </system.data>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>

--- a/aspnet/5-pubsub/lib/lib.csproj
+++ b/aspnet/5-pubsub/lib/lib.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Net.Compilers.1.1.1\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.1.1.1\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GoogleCloudSamples</RootNamespace>
     <AssemblyName>lib</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>8af7e7c8</NuGetPackageImportStamp>
     <TargetFrameworkProfile />
@@ -140,29 +140,32 @@
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.Helpers.dll</HintPath>
+    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.Mvc.4.0.20710.0\lib\net40\System.Web.Mvc.dll</HintPath>
+    <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.Razor.2.0.20710.0\lib\net40\System.Web.Razor.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Web.Optimization">
+      <HintPath>..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.dll</HintPath>
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.Deployment.dll</HintPath>
+    <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
+    <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/aspnet/5-pubsub/test/app.config
+++ b/aspnet/5-pubsub/test/app.config
@@ -1,19 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0" />
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797" />
+        <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797" />
+        <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>

--- a/aspnet/5-pubsub/test/test.csproj
+++ b/aspnet/5-pubsub/test/test.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>test</RootNamespace>
     <AssemblyName>test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>51f3a755</NuGetPackageImportStamp>
     <TargetFrameworkProfile />

--- a/aspnet/5-pubsub/worker/Web.config
+++ b/aspnet/5-pubsub/worker/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=301879
@@ -6,21 +6,21 @@
 <configuration>
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
   </configSections>
   <appSettings>
     <!-- Set to your Google project id as shown on the Google Developers Console -->
-    <add key="GoogleCloudSamples:ProjectId" value="YOUR-PROJECT-ID" />
+    <add key="GoogleCloudSamples:ProjectId" value="YOUR-PROJECT-ID"/>
     <!--
     Set to either mysql or datastore.
     If using mysql, update the connectionString far below, and then run Update-Database in the
     Package Manager Console.
     -->
-    <add key="GoogleCloudSamples:BookStore" value="datastore" />
-    <add key="webpages:Version" value="3.0.0.0" />
-    <add key="webpages:Enabled" value="false" />
-    <add key="ClientValidationEnabled" value="true" />
-    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+    <add key="GoogleCloudSamples:BookStore" value="datastore"/>
+    <add key="webpages:Version" value="3.0.0.0"/>
+    <add key="webpages:Enabled" value="false"/>
+    <add key="ClientValidationEnabled" value="true"/>
+    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -31,77 +31,77 @@
       </system.Web>
   -->
   <system.web>
-    <compilation debug="true" targetFramework="4.5" />
-    <httpRuntime targetFramework="4.5" />
+    <compilation debug="true" targetFramework="4.5.2"/>
+    <httpRuntime targetFramework="4.5"/>
   </system.web>
   <system.webServer>
     <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-      <remove name="OPTIONSVerbHandler" />
-      <remove name="TRACEVerbHandler" />
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
+      <remove name="OPTIONSVerbHandler"/>
+      <remove name="TRACEVerbHandler"/>
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
     </handlers>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0" />
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797" />
+        <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797" />
+        <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <connectionStrings>
-    <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd=" />
+    <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd="/>
   </connectionStrings>
   <entityFramework>
-    <defaultConnectionFactory type="MySql.Data.Entity.MySqlConnectionFactory, EntityFramework" />
+    <defaultConnectionFactory type="MySql.Data.Entity.MySqlConnectionFactory, EntityFramework"/>
     <providers>
-      <provider invariantName="MySql.Data.MySqlClient" type="MySql.Data.MySqlClient.MySqlProviderServices, MySql.Data.Entity.EF6, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+      <provider invariantName="MySql.Data.MySqlClient" type="MySql.Data.MySqlClient.MySqlProviderServices, MySql.Data.Entity.EF6, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"/>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
     </providers>
   </entityFramework>
   <system.data>
     <DbProviderFactories>
-      <remove invariant="MySql.Data.MySqlClient" />
-      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
+      <remove invariant="MySql.Data.MySqlClient"/>
+      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"/>
     </DbProviderFactories>
   </system.data>
   <system.codedom>
     <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701" />
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701"/>
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"/>
     </compilers>
   </system.codedom>
 </configuration>

--- a/aspnet/5-pubsub/worker/worker.csproj
+++ b/aspnet/5-pubsub/worker/worker.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>worker</RootNamespace>
     <AssemblyName>worker</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
@@ -103,6 +103,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -113,11 +114,13 @@
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
@@ -166,6 +169,7 @@
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="WebActivatorEx, Version=2.0.0.0, Culture=neutral, PublicKeyToken=7b26dc2a43f6a0d4, processorArchitecture=MSIL">
       <HintPath>..\packages\WebActivatorEx.2.0\lib\net40\WebActivatorEx.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
Also, propagate a few changes into 2-structured-data and 3-binary-data.

This required bumping the target .Net framework version back up to 4.5.2,
because Google.Apis.Storage.V1 requires it.