### PR TITLE
Move a TODO comment out of doc region

### DIFF
--- a/aspnet/2-structured-data/Models/DatastoreBookStore.cs
+++ b/aspnet/2-structured-data/Models/DatastoreBookStore.cs
@@ -74,6 +74,8 @@ namespace GoogleCloudSamples.Models
             return null == value ? null : new Property() { DateTimeValue = value };
         }
 
+        // TODO: Use reflection so we don't have to modify the code every time we add or drop
+        // a property from Book.
         /// <summary>
         /// Create a datastore entity with the same values as book.
         /// </summary>
@@ -82,8 +84,6 @@ namespace GoogleCloudSamples.Models
         /// [START toentity]
         public static Entity ToEntity(this Book book)
         {
-            // TODO: Use reflection so we don't have to modify the code every time we add or drop
-            // a property from Book.
             var entity = new Entity();
             entity.Properties =
                 new Dictionary<string, Property>();


### PR DESCRIPTION
This `TODO` comment will show up in our documentation.  It makes the documentation look unfinished.

@SurferJeffAtGoogle You previously mentioned wanting to keep this comment in the code, so I moved this out of the document region instead of removing it altogether.  If you would like the documentation to include a note about the possibility of reflection, let's rephrase this comment so it is an aside/recommendation rather than a `TODO`