### PR TITLE
Nuget mysql connector

### DIFF
--- a/aspnet/2-structured-data/2-structured-data.csproj
+++ b/aspnet/2-structured-data/2-structured-data.csproj
@@ -129,6 +129,10 @@
       <HintPath>packages\MySql.Data.Entity.6.9.8\lib\net45\MySql.Data.Entity.EF6.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
+      <HintPath>packages\MySql.Web.6.9.8\lib\net45\MySql.Web.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/aspnet/2-structured-data/Models/ApplicationDbContext.cs
+++ b/aspnet/2-structured-data/Models/ApplicationDbContext.cs
@@ -35,7 +35,7 @@ namespace GoogleCloudSamples.Models
         /// <summary>
         /// Pulls connection string from Web.config.
         /// </summary>
-        internal ApplicationDbContext()
+        internal ApplicationDbContext() : base("name=LocalMySqlServer")
         {
         }
     }

--- a/aspnet/2-structured-data/Web.config
+++ b/aspnet/2-structured-data/Web.config
@@ -125,8 +125,8 @@
     </assemblyBinding>
   </runtime>
   <connectionStrings>
-    <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd=" />
-  <remove name="LocalMySqlServer" /><add name="LocalMySqlServer" connectionString="" providerName="MySql.Data.MySqlClient" /></connectionStrings>
+    <add name="LocalMySqlServer" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=dotnetapp;Pwd=" providerName="MySql.Data.MySqlClient" />
+  </connectionStrings>
   <entityFramework>
     <defaultConnectionFactory type="MySql.Data.Entity.MySqlConnectionFactory, EntityFramework" />
     <providers>

--- a/aspnet/2-structured-data/Web.config
+++ b/aspnet/2-structured-data/Web.config
@@ -48,7 +48,34 @@
   <system.web>
     <compilation debug="true" targetFramework="4.5" />
     <httpRuntime targetFramework="4.5" />
-  </system.web>
+  <membership defaultProvider="MySQLMembershipProvider">
+      <providers>
+        <remove name="MySQLMembershipProvider" />
+        <add name="MySQLMembershipProvider" type="MySql.Web.Security.MySQLMembershipProvider, MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" connectionStringName="LocalMySqlServer" enablePasswordRetrieval="false" enablePasswordReset="true" requiresQuestionAndAnswer="true" applicationName="/" requiresUniqueEmail="false" passwordFormat="Clear" maxInvalidPasswordAttempts="5" minRequiredPasswordLength="7" minRequiredNonalphanumericCharacters="1" passwordAttemptWindow="10" passwordStrengthRegularExpression="" />
+      </providers>
+    </membership><profile defaultProvider="MySQLProfileProvider">
+      <providers>
+        <remove name="MySQLProfileProvider" />
+        <add name="MySQLProfileProvider" type="MySql.Web.Profile.MySQLProfileProvider, MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" connectionStringName="LocalMySqlServer" applicationName="/" />
+      </providers>
+    </profile><roleManager defaultProvider="MySQLRoleProvider">
+      <providers>
+        <remove name="MySQLRoleProvider" />
+        <add name="MySQLRoleProvider" type="MySql.Web.Security.MySQLRoleProvider, MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" connectionStringName="LocalMySqlServer" applicationName="/" />
+      </providers>
+    </roleManager><siteMap defaultProvider="MySqlSiteMapProvider">
+      <providers>
+        <remove name="MySqlSiteMapProvider" />
+        <add name="MySqlSiteMapProvider" type="MySql.Web.SiteMap.MySqlSiteMapProvider, MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" connectionStringName="LocalMySqlServer" applicationName="/" />
+      </providers>
+    </siteMap><webParts>
+      <personalization defaultProvider="MySQLPersonalizationProvider">
+        <providers>
+          <remove name="MySQLPersonalizationProvider" />
+          <add name="MySQLPersonalizationProvider" type="MySql.Web.Personalization.MySqlPersonalizationProvider, MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" connectionStringName="LocalMySqlServer" applicationName="/" />
+        </providers>
+      </personalization>
+    </webParts></system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
@@ -69,7 +96,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
@@ -99,7 +126,7 @@
   </runtime>
   <connectionStrings>
     <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd=" />
-  </connectionStrings>
+  <remove name="LocalMySqlServer" /><add name="LocalMySqlServer" connectionString="" providerName="MySql.Data.MySqlClient" /></connectionStrings>
   <entityFramework>
     <defaultConnectionFactory type="MySql.Data.Entity.MySqlConnectionFactory, EntityFramework" />
     <providers>

--- a/aspnet/2-structured-data/packages.config
+++ b/aspnet/2-structured-data/packages.config
@@ -27,6 +27,7 @@
   <package id="Modernizr" version="2.6.2" targetFramework="net452" />
   <package id="MySql.Data" version="6.9.8" targetFramework="net452" />
   <package id="MySql.Data.Entity" version="6.9.8" targetFramework="net452" />
+  <package id="MySql.Web" version="6.9.8" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
   <package id="Respond" version="1.2.0" targetFramework="net452" />
   <package id="Unity" version="4.0.1" targetFramework="net452" />

--- a/aspnet/3-binary-data/3-binary-data.csproj
+++ b/aspnet/3-binary-data/3-binary-data.csproj
@@ -141,6 +141,10 @@
       <HintPath>packages\MySql.Data.Entity.6.9.8\lib\net45\MySql.Data.Entity.EF6.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
+      <HintPath>packages\MySql.Web.6.9.8\lib\net45\MySql.Web.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/aspnet/3-binary-data/Models/ApplicationDbContext.cs
+++ b/aspnet/3-binary-data/Models/ApplicationDbContext.cs
@@ -35,7 +35,7 @@ namespace GoogleCloudSamples.Models
         /// <summary>
         /// Pulls connection string from Web.config.
         /// </summary>
-        internal ApplicationDbContext()
+        internal ApplicationDbContext() : base("name=LocalMySqlServer")
         {
         }
     }

--- a/aspnet/3-binary-data/Web.config
+++ b/aspnet/3-binary-data/Web.config
@@ -52,7 +52,34 @@
   <system.web>
     <compilation debug="true" targetFramework="4.5" />
     <httpRuntime targetFramework="4.5" />
-  </system.web>
+  <membership defaultProvider="MySQLMembershipProvider">
+      <providers>
+        <remove name="MySQLMembershipProvider" />
+        <add name="MySQLMembershipProvider" type="MySql.Web.Security.MySQLMembershipProvider, MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" connectionStringName="LocalMySqlServer" enablePasswordRetrieval="false" enablePasswordReset="true" requiresQuestionAndAnswer="true" applicationName="/" requiresUniqueEmail="false" passwordFormat="Clear" maxInvalidPasswordAttempts="5" minRequiredPasswordLength="7" minRequiredNonalphanumericCharacters="1" passwordAttemptWindow="10" passwordStrengthRegularExpression="" />
+      </providers>
+    </membership><profile defaultProvider="MySQLProfileProvider">
+      <providers>
+        <remove name="MySQLProfileProvider" />
+        <add name="MySQLProfileProvider" type="MySql.Web.Profile.MySQLProfileProvider, MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" connectionStringName="LocalMySqlServer" applicationName="/" />
+      </providers>
+    </profile><roleManager defaultProvider="MySQLRoleProvider">
+      <providers>
+        <remove name="MySQLRoleProvider" />
+        <add name="MySQLRoleProvider" type="MySql.Web.Security.MySQLRoleProvider, MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" connectionStringName="LocalMySqlServer" applicationName="/" />
+      </providers>
+    </roleManager><siteMap defaultProvider="MySqlSiteMapProvider">
+      <providers>
+        <remove name="MySqlSiteMapProvider" />
+        <add name="MySqlSiteMapProvider" type="MySql.Web.SiteMap.MySqlSiteMapProvider, MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" connectionStringName="LocalMySqlServer" applicationName="/" />
+      </providers>
+    </siteMap><webParts>
+      <personalization defaultProvider="MySQLPersonalizationProvider">
+        <providers>
+          <remove name="MySQLPersonalizationProvider" />
+          <add name="MySQLPersonalizationProvider" type="MySql.Web.Personalization.MySqlPersonalizationProvider, MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" connectionStringName="LocalMySqlServer" applicationName="/" />
+        </providers>
+      </personalization>
+    </webParts></system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
@@ -119,7 +146,7 @@
   </runtime>
   <connectionStrings>
     <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd=" />
-  </connectionStrings>
+  <remove name="LocalMySqlServer" /><add name="LocalMySqlServer" connectionString="" providerName="MySql.Data.MySqlClient" /></connectionStrings>
   <entityFramework>
     <defaultConnectionFactory type="MySql.Data.Entity.MySqlConnectionFactory, EntityFramework" />
     <providers>

--- a/aspnet/3-binary-data/Web.config
+++ b/aspnet/3-binary-data/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
   Copyright 2015 Google, Inc
 
@@ -145,8 +145,8 @@
     </assemblyBinding>
   </runtime>
   <connectionStrings>
-    <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd=" />
-  <remove name="LocalMySqlServer" /><add name="LocalMySqlServer" connectionString="" providerName="MySql.Data.MySqlClient" /></connectionStrings>
+    <add name="LocalMySqlServer" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=dotnetapp;Pwd=" providerName="MySql.Data.MySqlClient" />
+  </connectionStrings>
   <entityFramework>
     <defaultConnectionFactory type="MySql.Data.Entity.MySqlConnectionFactory, EntityFramework" />
     <providers>

--- a/aspnet/3-binary-data/packages.config
+++ b/aspnet/3-binary-data/packages.config
@@ -30,6 +30,7 @@
   <package id="Modernizr" version="2.8.3" targetFramework="net452" />
   <package id="MySql.Data" version="6.9.8" targetFramework="net452" />
   <package id="MySql.Data.Entity" version="6.9.8" targetFramework="net452" />
+  <package id="MySql.Web" version="6.9.8" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
   <package id="Respond" version="1.4.2" targetFramework="net452" />
   <package id="Unity" version="4.0.1" targetFramework="net452" />

--- a/aspnet/5-pubsub/bookshelf/Web.config
+++ b/aspnet/5-pubsub/bookshelf/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
   Copyright 2015 Google, Inc
 
@@ -94,7 +94,7 @@
     </assemblyBinding>
   </runtime>
   <connectionStrings>
-    <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd=" />
+    <add name="LocalMySqlServer" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=dotnetapp;Pwd=" providerName="MySql.Data.MySqlClient" />
   </connectionStrings>
   <entityFramework>
     <defaultConnectionFactory type="MySql.Data.Entity.MySqlConnectionFactory, EntityFramework" />

--- a/aspnet/5-pubsub/bookshelf/Web.config
+++ b/aspnet/5-pubsub/bookshelf/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   Copyright 2015 Google, Inc
 
@@ -21,25 +21,25 @@
 <configuration>
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <appSettings>
     <!-- Set to your Google project id as shown on the Google Developers Console -->
-    <add key="GoogleCloudSamples:ProjectId" value="YOUR-PROJECT-ID"/>
+    <add key="GoogleCloudSamples:ProjectId" value="YOUR-PROJECT-ID" />
     <!--
     Set to either mysql or datastore.
     If using mysql, update the connectionString far below, and then run Update-Database in the
     Package Manager Console.
     -->
-    <add key="GoogleCloudSamples:BookStore" value="datastore"/>
+    <add key="GoogleCloudSamples:BookStore" value="datastore" />
     <!-- Set to your Google Cloud Storage bucket -->
-    <add key="GoogleCloudSamples:BucketName" value="YOUR-BUCKET-NAME"/>
+    <add key="GoogleCloudSamples:BucketName" value="YOUR-BUCKET-NAME" />
     <!-- Configure the name of your appliation (optional) -->
-    <add key="GoogleCloudSamples:ApplicationName" value="Bookshelf Sample"/>
-    <add key="webpages:Version" value="3.0.0.0"/>
-    <add key="webpages:Enabled" value="false"/>
-    <add key="ClientValidationEnabled" value="true"/>
-    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
+    <add key="GoogleCloudSamples:ApplicationName" value="Bookshelf Sample" />
+    <add key="webpages:Version" value="3.0.0.0" />
+    <add key="webpages:Enabled" value="false" />
+    <add key="ClientValidationEnabled" value="true" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -50,69 +50,69 @@
       </system.Web>
   -->
   <system.web>
-    <compilation debug="true" targetFramework="4.5.2"/>
-    <httpRuntime targetFramework="4.5"/>
+    <compilation debug="true" targetFramework="4.5.2" />
+    <httpRuntime targetFramework="4.5" />
   </system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
+        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234"/>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0"/>
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797"/>
+        <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797"/>
+        <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <connectionStrings>
-    <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd="/>
+    <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd=" />
   </connectionStrings>
   <entityFramework>
-    <defaultConnectionFactory type="MySql.Data.Entity.MySqlConnectionFactory, EntityFramework"/>
+    <defaultConnectionFactory type="MySql.Data.Entity.MySqlConnectionFactory, EntityFramework" />
     <providers>
-      <provider invariantName="MySql.Data.MySqlClient" type="MySql.Data.MySqlClient.MySqlProviderServices, MySql.Data.Entity.EF6, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"/>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
+      <provider invariantName="MySql.Data.MySqlClient" type="MySql.Data.MySqlClient.MySqlProviderServices, MySql.Data.Entity.EF6, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
   <system.data>
     <DbProviderFactories>
-      <remove invariant="MySql.Data.MySqlClient"/>
-      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"/>
+      <remove invariant="MySql.Data.MySqlClient" />
+      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
     </DbProviderFactories>
   </system.data>
   <system.codedom>
     <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701"/>
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"/>
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
     </compilers>
   </system.codedom>
 </configuration>

--- a/aspnet/5-pubsub/lib/Models/ApplicationDbContext.cs
+++ b/aspnet/5-pubsub/lib/Models/ApplicationDbContext.cs
@@ -35,7 +35,7 @@ namespace GoogleCloudSamples.Models
         /// <summary>
         /// Pulls connection string from Web.config.
         /// </summary>
-        internal ApplicationDbContext()
+        internal ApplicationDbContext() : base("name=LocalMySqlServer")
         {
         }
     }

--- a/aspnet/5-pubsub/lib/app.config
+++ b/aspnet/5-pubsub/lib/app.config
@@ -1,53 +1,61 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <appSettings>
     <!-- Set to your Google project id as shown on the Google Developers Console -->
-    <add key="GoogleCloudSamples:ProjectId" value="YOUR-PROJECT-ID"/>
+    <add key="GoogleCloudSamples:ProjectId" value="YOUR-PROJECT-ID" />
     <!--
     Set to either mysql or datastore.
     If using mysql, update the connectionString far below, and then run Update-Database in the
     Package Manager Console.
     -->
-    <add key="GoogleCloudSamples:BookStore" value="datastore"/>
+    <add key="GoogleCloudSamples:BookStore" value="datastore" />
   </appSettings>
     <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
-				<assemblyIdentity name="System.Web.Mvc" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+				<assemblyIdentity name="System.Web.Mvc" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
 			</dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0"/>
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797"/>
+        <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797"/>
+        <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <connectionStrings>
-    <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd="/>
+    <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd=" />
   </connectionStrings>
   <entityFramework>
     <defaultConnectionFactory type="MySql.Data.Entity.MySqlConnectionFactory, EntityFramework"></defaultConnectionFactory>
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
-      <provider invariantName="MySql.Data.MySqlClient" type="MySql.Data.MySqlClient.MySqlProviderServices, MySql.Data.Entity.EF6, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"/>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+      <provider invariantName="MySql.Data.MySqlClient" type="MySql.Data.MySqlClient.MySqlProviderServices, MySql.Data.Entity.EF6, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
     </providers>
   </entityFramework>
   <system.data>
     <DbProviderFactories>
-      <remove invariant="MySql.Data.MySqlClient"/>
-      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"/>
+      <remove invariant="MySql.Data.MySqlClient" />
+      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
     </DbProviderFactories>
   </system.data>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>

--- a/aspnet/5-pubsub/lib/lib.csproj
+++ b/aspnet/5-pubsub/lib/lib.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Net.Compilers.1.1.1\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.1.1.1\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -119,6 +119,10 @@
     </Reference>
     <Reference Include="MySql.Data.Entity.EF6, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
       <HintPath>..\packages\MySql.Data.Entity.6.9.8\lib\net45\MySql.Data.Entity.EF6.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
+      <HintPath>..\packages\MySql.Web.6.9.8\lib\net45\MySql.Web.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/aspnet/5-pubsub/lib/packages.config
+++ b/aspnet/5-pubsub/lib/packages.config
@@ -20,6 +20,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="MySql.Data" version="6.9.8" targetFramework="net452" />
   <package id="MySql.Data.Entity" version="6.9.8" targetFramework="net452" />
+  <package id="MySql.Web" version="6.9.8" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
   <package id="Unity" version="4.0.1" targetFramework="net452" />
   <package id="Unity.Mvc" version="4.0.1" targetFramework="net452" />

--- a/aspnet/5-pubsub/test/app.config
+++ b/aspnet/5-pubsub/test/app.config
@@ -1,19 +1,27 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0"/>
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797"/>
+        <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797"/>
+        <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>

--- a/aspnet/5-pubsub/worker/Web.config
+++ b/aspnet/5-pubsub/worker/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=301879
@@ -6,21 +6,21 @@
 <configuration>
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <appSettings>
     <!-- Set to your Google project id as shown on the Google Developers Console -->
-    <add key="GoogleCloudSamples:ProjectId" value="YOUR-PROJECT-ID"/>
+    <add key="GoogleCloudSamples:ProjectId" value="YOUR-PROJECT-ID" />
     <!--
     Set to either mysql or datastore.
     If using mysql, update the connectionString far below, and then run Update-Database in the
     Package Manager Console.
     -->
-    <add key="GoogleCloudSamples:BookStore" value="datastore"/>
-    <add key="webpages:Version" value="3.0.0.0"/>
-    <add key="webpages:Enabled" value="false"/>
-    <add key="ClientValidationEnabled" value="true"/>
-    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
+    <add key="GoogleCloudSamples:BookStore" value="datastore" />
+    <add key="webpages:Version" value="3.0.0.0" />
+    <add key="webpages:Enabled" value="false" />
+    <add key="ClientValidationEnabled" value="true" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -31,77 +31,77 @@
       </system.Web>
   -->
   <system.web>
-    <compilation debug="true" targetFramework="4.5.2"/>
-    <httpRuntime targetFramework="4.5"/>
+    <compilation debug="true" targetFramework="4.5.2" />
+    <httpRuntime targetFramework="4.5" />
   </system.web>
   <system.webServer>
     <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
-      <remove name="OPTIONSVerbHandler"/>
-      <remove name="TRACEVerbHandler"/>
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
+        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234"/>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0"/>
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797"/>
+        <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797"/>
+        <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.17797" newVersion="1.11.0.17797" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <connectionStrings>
-    <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd="/>
+    <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd=" />
   </connectionStrings>
   <entityFramework>
-    <defaultConnectionFactory type="MySql.Data.Entity.MySqlConnectionFactory, EntityFramework"/>
+    <defaultConnectionFactory type="MySql.Data.Entity.MySqlConnectionFactory, EntityFramework" />
     <providers>
-      <provider invariantName="MySql.Data.MySqlClient" type="MySql.Data.MySqlClient.MySqlProviderServices, MySql.Data.Entity.EF6, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"/>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
+      <provider invariantName="MySql.Data.MySqlClient" type="MySql.Data.MySqlClient.MySqlProviderServices, MySql.Data.Entity.EF6, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
   <system.data>
     <DbProviderFactories>
-      <remove invariant="MySql.Data.MySqlClient"/>
-      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"/>
+      <remove invariant="MySql.Data.MySqlClient" />
+      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
     </DbProviderFactories>
   </system.data>
   <system.codedom>
     <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701"/>
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"/>
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
     </compilers>
   </system.codedom>
 </configuration>

--- a/aspnet/5-pubsub/worker/Web.config
+++ b/aspnet/5-pubsub/worker/Web.config
@@ -1,4 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2015 Google, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=301879
@@ -83,7 +98,7 @@
     </assemblyBinding>
   </runtime>
   <connectionStrings>
-    <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd=" />
+    <add name="LocalMySqlServer" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=dotnetapp;Pwd=" providerName="MySql.Data.MySqlClient" />
   </connectionStrings>
   <entityFramework>
     <defaultConnectionFactory type="MySql.Data.Entity.MySqlConnectionFactory, EntityFramework" />

--- a/aspnet/6-auth/6-auth.csproj
+++ b/aspnet/6-auth/6-auth.csproj
@@ -174,6 +174,10 @@
       <HintPath>packages\MySql.Data.Entity.6.9.8\lib\net45\MySql.Data.Entity.EF6.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
+      <HintPath>packages\MySql.Web.6.9.8\lib\net45\MySql.Web.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/aspnet/6-auth/Web.config
+++ b/aspnet/6-auth/Web.config
@@ -55,7 +55,34 @@
   <system.web>
     <compilation debug="true" targetFramework="4.5" />
     <httpRuntime targetFramework="4.5" />
-  </system.web>
+  <membership defaultProvider="MySQLMembershipProvider">
+      <providers>
+        <remove name="MySQLMembershipProvider" />
+        <add name="MySQLMembershipProvider" type="MySql.Web.Security.MySQLMembershipProvider, MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" connectionStringName="LocalMySqlServer" enablePasswordRetrieval="false" enablePasswordReset="true" requiresQuestionAndAnswer="true" applicationName="/" requiresUniqueEmail="false" passwordFormat="Clear" maxInvalidPasswordAttempts="5" minRequiredPasswordLength="7" minRequiredNonalphanumericCharacters="1" passwordAttemptWindow="10" passwordStrengthRegularExpression="" />
+      </providers>
+    </membership><profile defaultProvider="MySQLProfileProvider">
+      <providers>
+        <remove name="MySQLProfileProvider" />
+        <add name="MySQLProfileProvider" type="MySql.Web.Profile.MySQLProfileProvider, MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" connectionStringName="LocalMySqlServer" applicationName="/" />
+      </providers>
+    </profile><roleManager defaultProvider="MySQLRoleProvider">
+      <providers>
+        <remove name="MySQLRoleProvider" />
+        <add name="MySQLRoleProvider" type="MySql.Web.Security.MySQLRoleProvider, MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" connectionStringName="LocalMySqlServer" applicationName="/" />
+      </providers>
+    </roleManager><siteMap defaultProvider="MySqlSiteMapProvider">
+      <providers>
+        <remove name="MySqlSiteMapProvider" />
+        <add name="MySqlSiteMapProvider" type="MySql.Web.SiteMap.MySqlSiteMapProvider, MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" connectionStringName="LocalMySqlServer" applicationName="/" />
+      </providers>
+    </siteMap><webParts>
+      <personalization defaultProvider="MySQLPersonalizationProvider">
+        <providers>
+          <remove name="MySQLPersonalizationProvider" />
+          <add name="MySQLPersonalizationProvider" type="MySql.Web.Personalization.MySqlPersonalizationProvider, MySql.Web, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" connectionStringName="LocalMySqlServer" applicationName="/" />
+        </providers>
+      </personalization>
+    </webParts></system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
@@ -130,7 +157,7 @@
   </runtime>
   <connectionStrings>
     <add name="GoogleCloudSamples.Models.ApplicationDbContext" providerName="MySql.Data.MySqlClient" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=root;Pwd=" />
-  </connectionStrings>
+  <remove name="LocalMySqlServer" /><add name="LocalMySqlServer" connectionString="" providerName="MySql.Data.MySqlClient" /></connectionStrings>
   <entityFramework>
     <defaultConnectionFactory type="MySql.Data.Entity.MySqlConnectionFactory, EntityFramework" />
     <providers>

--- a/aspnet/6-auth/packages.config
+++ b/aspnet/6-auth/packages.config
@@ -38,6 +38,7 @@
   <package id="Modernizr" version="2.8.3" targetFramework="net452" />
   <package id="MySql.Data" version="6.9.8" targetFramework="net452" />
   <package id="MySql.Data.Entity" version="6.9.8" targetFramework="net452" />
+  <package id="MySql.Web" version="6.9.8" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="Respond" version="1.4.2" targetFramework="net452" />


### PR DESCRIPTION
When publishing the website, the nuget mysql connector requires a connection string called LocalMySqlServer, so I had to update Web.configs and ApplicationDbContext.css to also use that name.