### PR TITLE
Fix mysql issue reported by Steve.

### DIFF
--- a/aspnet/2-structured-data/Web.config
+++ b/aspnet/2-structured-data/Web.config
@@ -125,6 +125,7 @@
     </assemblyBinding>
   </runtime>
   <connectionStrings>
+    <remove name="LocalMySqlServer" />
     <add name="LocalMySqlServer" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=dotnetapp;Pwd=" providerName="MySql.Data.MySqlClient" />
   </connectionStrings>
   <entityFramework>

--- a/aspnet/3-binary-data/Web.config
+++ b/aspnet/3-binary-data/Web.config
@@ -145,6 +145,7 @@
     </assemblyBinding>
   </runtime>
   <connectionStrings>
+    <remove name="LocalMySqlServer" />
     <add name="LocalMySqlServer" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=dotnetapp;Pwd=" providerName="MySql.Data.MySqlClient" />
   </connectionStrings>
   <entityFramework>

--- a/aspnet/5-pubsub/bookshelf/Web.config
+++ b/aspnet/5-pubsub/bookshelf/Web.config
@@ -94,6 +94,7 @@
     </assemblyBinding>
   </runtime>
   <connectionStrings>
+    <remove name="LocalMySqlServer" />
     <add name="LocalMySqlServer" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=dotnetapp;Pwd=" providerName="MySql.Data.MySqlClient" />
   </connectionStrings>
   <entityFramework>

--- a/aspnet/5-pubsub/worker/Web.config
+++ b/aspnet/5-pubsub/worker/Web.config
@@ -98,6 +98,7 @@
     </assemblyBinding>
   </runtime>
   <connectionStrings>
+    <remove name="LocalMySqlServer" />
     <add name="LocalMySqlServer" connectionString="Server=1.2.3.4;Database=bookshelf;Uid=dotnetapp;Pwd=" providerName="MySql.Data.MySqlClient" />
   </connectionStrings>
   <entityFramework>


### PR DESCRIPTION
He was seeing an error message complaining about duplicate
LocalMysqlServer entries.

When I first added the dependency to the Mysql.Web nuget package in
https://github.com/GoogleCloudPlatform/getting-started-dotnet/commit/db9b167d2dde5343e049f062867eeac070d50650
it added a <remove name="LocalMySqlServer /> element that I couldn't prove
was necessary and cluttered the code, so I removed it.  Turns out, in some
cases, like the case Steve discovered, it is necessary.