### PR TITLE
Print a summary of all successes and failures.

### DIFF
--- a/aspnet/2-structured-data/runTestsWithDatastore.ps1
+++ b/aspnet/2-structured-data/runTestsWithDatastore.ps1
@@ -1,0 +1,16 @@
+﻿# Copyright(c) 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+BuildSolution
+$env:GoogleCloudSamples:BookStore = "datastore"
+RunIISExpressTest

--- a/aspnet/2-structured-data/runTestsWithSql.ps1
+++ b/aspnet/2-structured-data/runTestsWithSql.ps1
@@ -12,16 +12,14 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 BuildSolution
-$env:GoogleCloudSamples:BookStore = "datastore"
-RunIISExpressTest
-$failed = $LASTEXITCODE
 $env:GoogleCloudSamples:BookStore = "mysql"
 # Update the database before running the test.
 cp packages\EntityFramework.*\tools\migrate.exe bin\.
 cd bin
 .\migrate.exe 2-structured-data.dll /startupConfigurationFile="..\Web.config"
-$failed += $LASTEXITCODE
+if ($LASTEXITCODE) {
+    throw "migrate.exe failed with error code $LASTEXITCODE"
+}
 cd ..
 RunIISExpressTest
-$failed += $LASTEXITCODE
 $failed


### PR DESCRIPTION
And fix the code so that all failures propagate up to the top.
Powershell return value semantics are very strange.

Here's a sample summary:
===============================================================================
7 SUCCEEDED
aspnet\1-hello-world\runTests.ps1
aspnet\2-structured-data\runTestsWithDatastore.ps1
aspnet\3-binary-data\runTests.ps1
aspnet\5-pubsub\runTests.ps1
aspnet\5-pubsub\bookshelf\runTests.ps1
aspnet\5-pubsub\test\runTests.ps1
aspnet\5-pubsub\worker\runTests.ps1
2 FAILED
aspnet\2-structured-data\runTestsWithSql.ps1
aspnet\6-auth\runTests.ps1