### PR TITLE
Update Google.Storage.V1 to 0.1.0-CI00063.

### DIFF
--- a/aspnet/3-binary-data/3-binary-data.csproj
+++ b/aspnet/3-binary-data/3-binary-data.csproj
@@ -89,7 +89,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Storage.V1, Version=0.1.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Storage.V1.0.1.0-CI00039\lib\net45\Google.Storage.V1.dll</HintPath>
+      <HintPath>packages\Google.Storage.V1.0.1.0-CI00063\lib\net45\Google.Storage.V1.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">

--- a/aspnet/3-binary-data/App_Start/UnityConfig.cs
+++ b/aspnet/3-binary-data/App_Start/UnityConfig.cs
@@ -119,8 +119,7 @@ namespace GoogleCloudSamples
 
             container.RegisterInstance<ImageUploader>(
                 new ImageUploader(
-                  GetConfigVariable("GoogleCloudSamples:BucketName"),
-                  "Bookshelf.NET-Step3"
+                  GetConfigVariable("GoogleCloudSamples:BucketName")
                 )
             );
         }

--- a/aspnet/3-binary-data/Global.asax.cs
+++ b/aspnet/3-binary-data/Global.asax.cs
@@ -12,6 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+using Google.Storage.V1;
 using System.Web.Mvc;
 using System.Web.Routing;
 
@@ -21,6 +22,10 @@ namespace GoogleCloudSamples
     {
         protected void Application_Start()
         {
+            // This helps Google determine how many developers have been through
+            // this Getting Started guide. Regular applications do not need to set this.
+            StorageClientImpl.ApplicationName = "Bookshelf.NET-Step3";
+
             AreaRegistration.RegisterAllAreas();
             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
             RouteConfig.RegisterRoutes(RouteTable.Routes);

--- a/aspnet/3-binary-data/Services/ImageUploader.cs
+++ b/aspnet/3-binary-data/Services/ImageUploader.cs
@@ -25,12 +25,11 @@ namespace GoogleCloudSamples.Services
         private readonly string _bucketName;
         private readonly StorageClient _storageClient;
 
-        public ImageUploader(string bucketName, string applicationName)
+        public ImageUploader(string bucketName)
         {
             _bucketName = bucketName;
             // [START storageclient]
-            _storageClient = StorageClient
-                .FromApplicationCredentials(applicationName).Result;
+            _storageClient = StorageClient.Create();
             // [END storageclient]
         }
 

--- a/aspnet/3-binary-data/packages.config
+++ b/aspnet/3-binary-data/packages.config
@@ -10,7 +10,7 @@
   <package id="Google.Apis.Core" version="1.11.1" targetFramework="net45" />
   <package id="Google.Apis.Datastore.v1beta2" version="1.10.1.280" targetFramework="net452" />
   <package id="Google.Apis.Storage.v1" version="1.12.0.448" targetFramework="net45" />
-  <package id="Google.Storage.V1" version="0.1.0-CI00039" targetFramework="net45" />
+  <package id="Google.Storage.V1" version="0.1.0-CI00063" targetFramework="net45" />
   <package id="Ix-Async" version="1.2.5" targetFramework="net452" />
   <package id="jQuery" version="2.2.0" targetFramework="net452" />
   <package id="jQuery.Validation" version="1.14.0" targetFramework="net452" />

--- a/aspnet/5-pubsub/bookshelf/App_Start/UnityConfig.cs
+++ b/aspnet/5-pubsub/bookshelf/App_Start/UnityConfig.cs
@@ -53,8 +53,7 @@ namespace GoogleCloudSamples.App_Start
 
             container.RegisterInstance<ImageUploader>(
                 new ImageUploader(
-                  LibUnityConfig.GetConfigVariable("GoogleCloudSamples:BucketName"),
-                  "Bookshelf.NET-Step5"
+                  LibUnityConfig.GetConfigVariable("GoogleCloudSamples:BucketName")
                 )
             );
         }

--- a/aspnet/5-pubsub/bookshelf/Global.asax.cs
+++ b/aspnet/5-pubsub/bookshelf/Global.asax.cs
@@ -12,6 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+using Google.Storage.V1;
 using System.Web.Mvc;
 using System.Web.Routing;
 
@@ -21,6 +22,10 @@ namespace GoogleCloudSamples
     {
         protected void Application_Start()
         {
+            // This helps Google determine how many developers have been through
+            // this Getting Started guide. Regular applications do not need to set this.
+            StorageClientImpl.ApplicationName = "Bookshelf.NET-Step5";
+
             AreaRegistration.RegisterAllAreas();
             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
             RouteConfig.RegisterRoutes(RouteTable.Routes);

--- a/aspnet/5-pubsub/bookshelf/Services/ImageUploader.cs
+++ b/aspnet/5-pubsub/bookshelf/Services/ImageUploader.cs
@@ -25,12 +25,11 @@ namespace GoogleCloudSamples.Services
         private readonly string _bucketName;
         private readonly StorageClient _storageClient;
 
-        public ImageUploader(string bucketName, string applicationName)
+        public ImageUploader(string bucketName)
         {
             _bucketName = bucketName;
             // [START storageclient]
-            _storageClient = StorageClient
-                .FromApplicationCredentials(applicationName).Result;
+            _storageClient = StorageClient.Create();
             // [END storageclient]
         }
 

--- a/aspnet/5-pubsub/bookshelf/bookshelf.csproj
+++ b/aspnet/5-pubsub/bookshelf/bookshelf.csproj
@@ -81,7 +81,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Storage.V1, Version=0.1.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Storage.V1.0.1.0-CI00039\lib\net45\Google.Storage.V1.dll</HintPath>
+      <HintPath>..\packages\Google.Storage.V1.0.1.0-CI00063\lib\net45\Google.Storage.V1.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">

--- a/aspnet/5-pubsub/bookshelf/packages.config
+++ b/aspnet/5-pubsub/bookshelf/packages.config
@@ -9,7 +9,7 @@
   <package id="Google.Apis.Auth" version="1.11.1" targetFramework="net45" />
   <package id="Google.Apis.Core" version="1.11.1" targetFramework="net45" />
   <package id="Google.Apis.Storage.v1" version="1.12.0.448" targetFramework="net45" />
-  <package id="Google.Storage.V1" version="0.1.0-CI00039" targetFramework="net45" />
+  <package id="Google.Storage.V1" version="0.1.0-CI00063" targetFramework="net45" />
   <package id="jQuery" version="1.10.2" targetFramework="net452" />
   <package id="jQuery.Validation" version="1.11.1" targetFramework="net452" />
   <package id="log4net" version="2.0.3" targetFramework="net452" />

--- a/aspnet/6-auth/6-auth.csproj
+++ b/aspnet/6-auth/6-auth.csproj
@@ -90,7 +90,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Storage.V1, Version=0.1.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Storage.V1.0.1.0-CI00039\lib\net45\Google.Storage.V1.dll</HintPath>
+      <HintPath>packages\Google.Storage.V1.0.1.0-CI00063\lib\net45\Google.Storage.V1.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">

--- a/aspnet/6-auth/App_Start/UnityConfig.cs
+++ b/aspnet/6-auth/App_Start/UnityConfig.cs
@@ -104,8 +104,7 @@ namespace GoogleCloudSamples
 
             container.RegisterInstance<ImageUploader>(
                 new ImageUploader(
-                  Config.GetConfigVariable("GoogleCloudSamples:BucketName"),
-                  Config.GetConfigVariable("GoogleCloudSamples:ApplicationName")
+                  Config.GetConfigVariable("GoogleCloudSamples:BucketName")
                 )
             );
         }

--- a/aspnet/6-auth/Global.asax.cs
+++ b/aspnet/6-auth/Global.asax.cs
@@ -16,6 +16,7 @@ using System.Web.Mvc;
 using System.Web.Routing;
 using System.Web.Helpers;
 using System.Security.Claims;
+using Google.Storage.V1;
 
 namespace GoogleCloudSamples
 {
@@ -23,6 +24,11 @@ namespace GoogleCloudSamples
     {
         protected void Application_Start()
         {
+            // This helps Google determine how many developers have been through
+            // this Getting Started guide. Regular applications do not need to set this.
+            StorageClientImpl.ApplicationName =
+                Config.GetConfigVariable("GoogleCloudSamples:ApplicationName");
+
             AreaRegistration.RegisterAllAreas();
             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
             RouteConfig.RegisterRoutes(RouteTable.Routes);

--- a/aspnet/6-auth/Services/ImageUploader.cs
+++ b/aspnet/6-auth/Services/ImageUploader.cs
@@ -28,17 +28,15 @@ namespace GoogleCloudSamples.Services
         private readonly string _bucketName;
         private readonly string _applicationName;
 
-        public ImageUploader(string bucketName, string applicationName)
+        public ImageUploader(string bucketName)
         {
             _bucketName = bucketName;
-            _applicationName = applicationName;
         }
 
         public async Task<String> UploadImage(HttpPostedFileBase image, long id)
         {
             // Create client and use it to upload object to Cloud Storage
-            var client = await StorageClient
-                .FromApplicationCredentials(_applicationName);
+            var client = await StorageClient.CreateAsync();
 
             var imageAcl = ObjectsResource
                 .InsertMediaUpload.PredefinedAclEnum.PublicRead;
@@ -56,8 +54,7 @@ namespace GoogleCloudSamples.Services
 
         public async Task DeleteUploadedImage(long id)
         {
-            var client = await StorageClient
-                .FromApplicationCredentials(_applicationName);
+            var client = await StorageClient.CreateAsync();
             client.DeleteObject(_bucketName, id.ToString());
         }
     }

--- a/aspnet/6-auth/packages.config
+++ b/aspnet/6-auth/packages.config
@@ -10,7 +10,7 @@
   <package id="Google.Apis.Core" version="1.11.1" targetFramework="net45" />
   <package id="Google.Apis.Datastore.v1beta2" version="1.10.1.280" targetFramework="net452" />
   <package id="Google.Apis.Storage.v1" version="1.12.0.448" targetFramework="net45" />
-  <package id="Google.Storage.V1" version="0.1.0-CI00039" targetFramework="net45" />
+  <package id="Google.Storage.V1" version="0.1.0-CI00063" targetFramework="net45" />
   <package id="Ix-Async" version="1.2.5" targetFramework="net452" />
   <package id="jQuery" version="2.2.0" targetFramework="net452" />
   <package id="jQuery.Validation" version="1.14.0" targetFramework="net452" />


### PR DESCRIPTION
This has simpler (and more consistent) client creation.
The setting of the application name has been moved to Global.asax.cs, so as
not to distract users (who won't typically need to use this). Please let me know if
you would prefer it elsewhere.

// cc @SurferJeffAtGoogle 