### PR TITLE
Display a custom error page with a link to the set up steps in our docs.

### DIFF
--- a/aspnet/2-structured-data/App_Start/FilterConfig.cs
+++ b/aspnet/2-structured-data/App_Start/FilterConfig.cs
@@ -16,11 +16,22 @@ using System.Web.Mvc;
 
 namespace GoogleCloudSamples
 {
+    internal class CustomHandleErrorAttribute : HandleErrorAttribute
+    {
+        public override void OnException(ExceptionContext filterContext)
+        {
+            ViewDataDictionary viewData = new ViewDataDictionary(filterContext);
+            filterContext.Result = new ViewResult() { ViewName = "Error", ViewData = viewData };
+            filterContext.HttpContext.Response.StatusCode = 500;
+            filterContext.ExceptionHandled = true;
+        }
+    }
+
     public class FilterConfig
     {
         public static void RegisterGlobalFilters(GlobalFilterCollection filters)
         {
-            filters.Add(new HandleErrorAttribute());
+            filters.Add(new CustomHandleErrorAttribute());
         }
     }
 }

--- a/aspnet/2-structured-data/Controllers/HomeController.cs
+++ b/aspnet/2-structured-data/Controllers/HomeController.cs
@@ -23,6 +23,11 @@ namespace GoogleCloudSamples.Controllers
             return Redirect("/Books");
         }
 
+        public ActionResult Throw()
+        {
+            throw new System.Exception("For testing purposes only.");
+        }
+
         public ActionResult Error()
         {
             return View();

--- a/aspnet/2-structured-data/Views/Shared/Error.cshtml
+++ b/aspnet/2-structured-data/Views/Shared/Error.cshtml
@@ -15,6 +15,20 @@
     //
     ViewData["Title"] = "Error";
 }
+@model System.Web.Mvc.ExceptionContext
 
-<h1 class="text-danger">Error.</h1>
-<h2 class="text-danger">An error occurred while processing your request.</h2>
+<h1 class="text-danger">Uncaught Exception</h1>
+<h2 class="text-danger">
+    Before running this sample, complete all the
+    <a href="https://cloud.google.com/dotnet/getting-started/tutorial-app#before-you-begin">
+    set up steps</a>.
+</h2>
+
+<pre>
+Exception in @Model.Controller.ToString():
+
+<span id="message">@Model.Exception.Message</span>
+
+Stack Trace:
+@Model.Exception.StackTrace
+</pre>

--- a/aspnet/2-structured-data/Views/Web.config
+++ b/aspnet/2-structured-data/Views/Web.config
@@ -54,5 +54,6 @@
         <add assembly="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
       </assemblies>
     </compilation>
+    <customErrors mode="On" defaultRedirect="Error" />
   </system.web>
 </configuration>

--- a/aspnet/2-structured-data/test.js
+++ b/aspnet/2-structured-data/test.js
@@ -47,6 +47,12 @@ casper.thenClick('button', function (response) {
     this.test.assertEquals(response.status, 200);
 });
 
+casper.thenOpen(host + '/Home/Throw', function (response) {
+    this.test.assertEquals(response.status, 500);
+    this.test.assertEquals(this.fetchText('#message'),
+        'For testing purposes only.');
+});
+
 casper.run(function () {
     this.test.done();
     this.test.renderResults(true);


### PR DESCRIPTION
I suspect github foragers who stumble upon this sample are just going to press
F5 without reading anything.  This will give them a pointer to what they
need to do to make the code work.