### PR TITLE
fix: Remove bucket name from appsettings.jsons

### DIFF
--- a/Bookshelf/appsettings.json
+++ b/Bookshelf/appsettings.json
@@ -5,7 +5,6 @@
     }
   },
   "AllowedHosts": "*",
-  "Bucket": "my-bucket-id",
   "BookStore": "Firestore",
   "ConnectionStrings": {
     "SqlServer": "Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;",


### PR DESCRIPTION
Having the bucket name in appsettings.jsons is not compatible with the steps described in the [sample tutorial](https://cloud.google.com/dotnet/docs/getting-started#storing-file-uploads-in-cloud-storage)