### PR TITLE
Change ComputeEngine.pubxml to be self-contained

### DIFF
--- a/HelloWorld/Properties/PublishProfiles/ComputeEngine.pubxml
+++ b/HelloWorld/Properties/PublishProfiles/ComputeEngine.pubxml
@@ -13,7 +13,8 @@ by editing this MSBuild file. In order to learn more about this please visit htt
     <ExcludeApp_Data>False</ExcludeApp_Data>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <ProjectGuid>94827da7-c3c7-4745-82bf-392366fdcca4</ProjectGuid>
-    <SelfContained>false</SelfContained>
+    <SelfContained>true</SelfContained>
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <_IsPortable>true</_IsPortable>
     <MSDeployServiceURL></MSDeployServiceURL>
     <DeployIisAppPath>Default Web Site</DeployIisAppPath>


### PR DESCRIPTION
The [tutorial](https://cloud.google.com/dotnet/docs/getting-started/getting-started-on-compute-engine) referencing this demo code uses an ASPNET VM image based on .NET Core 2.1 with runtime 2.1.4. Current runtime of .NET Core 2.1 uses a newer ASP.NET Core assemblies that are not installed on the VM. Deploying a self-contained web app solves this issue.
